### PR TITLE
Implement sitemap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         }
     ],
     "require": {
+        "php": ">=5.4",
         "contao/core-bundle": "^4.4.8"
     },
     "extra": {

--- a/src/EventListener/GetSearchablePagesListener.php
+++ b/src/EventListener/GetSearchablePagesListener.php
@@ -80,7 +80,7 @@ class GetSearchablePagesListener
                 continue;
             }
 
-            $jobs = Jobs::findBy(['pid IN('.implode(',', array_map('intval', $organisations)).')'], []);
+            $jobs = Jobs::findBy(['pid IN(' . implode(',', array_map('intval', $organisations)) . ')'], []);
 
             if (null === $jobs) {
                 continue;

--- a/src/EventListener/GetSearchablePagesListener.php
+++ b/src/EventListener/GetSearchablePagesListener.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Slashworks\ContaoSimpleJobManagerBundle\EventListener;
+
+use Contao\ContentModel;
+use Contao\Date;
+use Contao\ModuleModel;
+use Contao\PageModel;
+use Contao\StringUtil;
+use Slashworks\ContaoSimpleJobManagerBundle\Models\Jobs;
+
+class GetSearchablePagesListener
+{
+    /**
+     * @param array $pages
+     * @param int|null $rootId
+     * @param bool $isSitemap
+     * @param string $language
+     * 
+     * @return array
+     */
+    public function __invoke($pages, $rootId = null, $isSitemap = false, $language = null)
+    {
+        // Load all job list modules
+        $modules = ModuleModel::findByType('job-list');
+
+        if (null === $modules) {
+            return $pages;
+        }
+
+        $detailPageIds = [];
+
+        foreach ($modules as $module) {
+            // Check if the module has a detail page defined
+            if (empty($module->jumpTo)) {
+                continue;
+            }
+
+            // Find all content elements integrating this module
+            $time = Date::floorToMinute();
+            $elements = ContentModel::findBy([
+                "invisible='' AND (start='' OR start<='$time') AND (stop='' OR stop>'$time')",
+                "type = 'module'", 
+                "ptable = 'tl_article'",
+                'module = ?',
+            ], [$module->id]);
+
+            if (null === $elements) {
+                continue;
+            }
+
+            // Check if we already processed this detail page
+            if (\in_array((int) $module->jumpTo, $detailPageIds, true)) {
+                continue;
+            }
+
+            $detailPageIds[] = (int) $module->jumpTo;
+            $page = PageModel::findPublishedById((int) $module->jumpTo);
+
+            if (null === $page) {
+                continue;
+            }
+
+            $page->loadDetails();
+
+            // Check if page belongs to current root
+            if (null !== $rootId && (int) $rootId !== (int) $page->rootId) {
+                continue;
+            }
+
+            // Load all jobs for this list
+            $organisations = StringUtil::deserialize($module->organisation, true);
+
+            if (empty($organisations)) {
+                continue;
+            }
+
+            $jobs = Jobs::findBy(['pid IN('.implode(',', array_map('intval', $organisations)).')'], []);
+
+            if (null === $jobs) {
+                continue;
+            }
+
+            foreach ($jobs as $job) {
+                $pages[] = $page->getAbsoluteUrl('/'.$job->alias);
+            }
+        }
+
+        return $pages;
+    }
+}

--- a/src/EventListener/GetSearchablePagesListener.php
+++ b/src/EventListener/GetSearchablePagesListener.php
@@ -61,6 +61,11 @@ class GetSearchablePagesListener
                 continue;
             }
 
+            // Check if indexing is disabled
+            if ('noindex,nofollow' === $page->robots) {
+                continue;
+            }
+
             $page->loadDetails();
 
             // Check if page belongs to current root

--- a/src/Module/JobList.php
+++ b/src/Module/JobList.php
@@ -3,13 +3,9 @@
 namespace Slashworks\ContaoSimpleJobManagerBundle\Module;
 
 use Contao\Controller;
-use Contao\CoreBundle\ContaoCoreBundle;
-use Contao\Date;
-use Contao\FilesModel;
-use Contao\Image\PictureConfiguration;
-use Contao\Input;
 use Contao\Module;
 use Contao\PageModel;
+use Contao\StringUtil;
 use Slashworks\ContaoSimpleJobManagerBundle\Models\Jobs;
 
 /**
@@ -58,11 +54,14 @@ class JobList extends Module
         );
 
         if (!$bExpiredJobs) {
-            $aOptions['column'][] = ' validthrough >= ' . $dTime;
+            $aOptions['column'][] = 'validthrough >= ' . $dTime;
         }
 
-        $aJobsByOrganisation = array();
-        $oOrganisations = \Slashworks\ContaoSimpleJobManagerBundle\Models\Organisation::findAll();
+        $organisations = StringUtil::deserialize($this->organisation, true);
+
+        if (!empty($organisations)) {
+            $aOptions['column'][] = 'pid IN(' . implode(',', array_map('intval', $organisations)) . ')';
+        }
 
         $oJobs = Jobs::findAll($aOptions);
 

--- a/src/Module/JobList.php
+++ b/src/Module/JobList.php
@@ -54,7 +54,7 @@ class JobList extends Module
 
         $aOptions = array
         (
-            'order'  => 'pid',$this->jobsorting . ' ' . $this->sortorder,
+            'order'  => 'pid, '.$this->jobsorting . ' ' . $this->sortorder,
         );
 
         if (!$bExpiredJobs) {
@@ -74,7 +74,7 @@ class JobList extends Module
 
                 // generate URL
                 $oPage = PageModel::findBy('id', $this->jumpTo);
-                $oJob->jobJumpTo = Controller::generateFrontendUrl($oPage->row(), '/job/' . $oJob->alias);
+                $oJob->jobJumpTo = Controller::generateFrontendUrl($oPage->row(), '/' . $oJob->alias);
                 $oJob->organisation = $oJob->getRelated('pid');
 
             }

--- a/src/Module/JobReader.php
+++ b/src/Module/JobReader.php
@@ -4,6 +4,7 @@ namespace Slashworks\ContaoSimpleJobManagerBundle\Module;
 
 use Contao\Controller;
 use Contao\CoreBundle\Exception\PageNotFoundException;
+use Contao\CoreBundle\Exception\RedirectResponseException;
 use Contao\Date;
 use Contao\FilesModel;
 use Contao\Input;
@@ -49,9 +50,14 @@ class JobReader extends Module
     {
         Controller::loadLanguageFile('tl_sjm_jobs');
 
+        // Redirect to new URL without /job
+        if (!empty($GLOBALS['objPage']) && null !== Input::get('job')) {
+            throw new RedirectResponseException($GLOBALS['objPage']->getAbsoluteUrl('/'.Input::get('job')));
+        }
+
         $aOptions = array
         (
-            'alias' => \Input::get('job')
+            'alias' => Input::get('auto_item')
         );
 
         $oJob = \Slashworks\ContaoSimpleJobManagerBundle\Models\Jobs::findOneBy('alias', $aOptions['alias']);

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -1,5 +1,7 @@
 <?php
 
+use Slashworks\ContaoSimpleJobManagerBundle\EventListener\GetSearchablePagesListener;
+
 /**
  * Backend modules
  */
@@ -31,3 +33,8 @@ $GLOBALS['FE_MOD']['sjm']['job-reader'] = 'Slashworks\ContaoSimpleJobManagerBund
 
 
 $GLOBALS['sjm']['jobsorting']['options'] = array('dateposted','validthrough','title','jobnumber','business');
+
+/**
+ * Register Hooks
+ */
+$GLOBALS['TL_HOOKS']['getSearchablePages'][] = [GetSearchablePagesListener::class, '__invoke'];


### PR DESCRIPTION
This PR implements a `getSearchablePages` hook, so that the job detail pages appear in Contao's sitemap.

_Note:_ usually the target page is defined in the parent container (see news archive for example). However in this extension the target page is currently only defined in the list module itself. Thus the implementation check for all published list modules and uses their target pages to generate the URLs.

This PR also implements a change to the job alias parameter: now the `auto_item` is used and the old `/job/…` URL will automatically be redirected. This enables you to use the __Require item__ page setting (should only be enabled for _new_ projects), so that the detail page _without_ the parameter can be omitted from the sitemap.

This PR also fixes an issue with the sorting definiton of the list (fixes #3).

This PR also fixes that the organisation selection in the list module is ignored (fixes #2).